### PR TITLE
Changed CV list reference

### DIFF
--- a/lib/checks/compatlist.js
+++ b/lib/checks/compatlist.js
@@ -39,19 +39,9 @@ request = request.defaults({
         'User-Agent': config.user_agent_edge}});
 
 function getCompatListUrl(ieversion) {
-    var cvlistUrl;
-    switch (ieversion) {
-        case 'ie10':
-            cvlistUrl = config.compatlisturlGDR;
-            break;
-        case 'ie9':
-            cvlistUrl = config.compatlisturlSDR;
-            break;
-        default:
-            cvlistUrl = config.compatlisturlSDR;
-            break;
-    }
-    return cvlistUrl;
+    // actually there is no need to check for other IE versions as this is the list to be compatible with.
+    // we need a mechanism to sync this url with the CV list updates through IE Partner Outreach
+    return config.compatlisturlEdgeDesktop;
 }
 
 function addExplicitFlashBlockedSites(result) {

--- a/lib/checks/config.js
+++ b/lib/checks/config.js
@@ -1,8 +1,7 @@
 module.exports.user_agent_edge = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.81 Safari/537.36 Edge/12.0';
 module.exports.user_agent_chrome = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.81 Safari/537.36';
 
-module.exports.compatlisturlGDR = 'http://cvlist.ie.microsoft.com/0315000/1426178821/iecompatviewlist.xml';
-module.exports.compatlisturlSDR = 'http://cvlist.ie.microsoft.com/0315000/1426178821/iecompatviewlist.xml';
+module.exports.compatlisturlEdgeDesktop = 'http://cvlist.ie.microsoft.com/edge/desktop/1432152749/edgecompatviewlist.xml';
 
 // Allow SVG, SWF and Silverlight and disallow everything else
 module.exports.check_pluginfree_options = { allowFlash: true, allowSilverlight: true, allowOthers: false };


### PR DESCRIPTION
- removed IE9 / IE10 reference
- added curren Edge CV list URI

I don't think that we need to check for older versions, as wrote in the Code comments, we need a way to sync the CV list URL with updates to the edge version