### PR TITLE
after incomplete, no longer restarts for today

### DIFF
--- a/App_Data/jobs/triggered/scan/run.js
+++ b/App_Data/jobs/triggered/scan/run.js
@@ -780,8 +780,8 @@ function doWork(websites, progress) {
 
         tryAndWrapUp = function () {
             if (originalSuffix != suffix) {
-                console.log("Starting with a fresh run for today");
-                startRun();
+                console.log("That's all folks. I finished a previous run, perhaps you'd like to reschedule me to start with a fresh run for today");
+                //startRun();
             }
             else {
                 console.log("That's all folks!");


### PR DESCRIPTION
Batch checks to see if there is an incomplete scan in the last 10 days. If there is, it will finish it first. Afterwards, it used to start a 'fresh run' for today. This is now disabled, the batch either finishes an old incomplete run, OR it does a fresh run if no incomplete run was found.