### PR TITLE
Latest version of Modernizer not included in check-libs.js #19 

### DIFF
--- a/lib/checks/check-libs.js
+++ b/lib/checks/check-libs.js
@@ -148,6 +148,7 @@ var libraries = [
             { major: "2.5.", minor: "2" },
             { major: "2.6.", minor: "2" },
             { major: "2.7.", minor: "1" }
+            { major: "2.8.", minor: "0" }
         ],
         check: function (scriptText) {
             // Static analysis. :(  The version is set as a local variable, far from

--- a/lib/checks/check-libs.js
+++ b/lib/checks/check-libs.js
@@ -147,7 +147,7 @@ var libraries = [
             { major: "1.1.", minor: "" },
             { major: "2.5.", minor: "2" },
             { major: "2.6.", minor: "2" },
-            { major: "2.7.", minor: "1" }
+            { major: "2.7.", minor: "1" },
             { major: "2.8.", minor: "0" }
         ],
         check: function (scriptText) {


### PR DESCRIPTION
Adds new `minVersion` for Modernizer to include 2.8.0