### PR TITLE
Converting version parts to numbers to prevent string comparison

### DIFF
--- a/lib/checks/check-libs.js
+++ b/lib/checks/check-libs.js
@@ -390,6 +390,9 @@ function compareVersions(version1, version2) {
 
     var v1 = version1.split(".");
     var v2 = version2.split(".");
+   
+    v1 = v1.map(Number);
+    v2 = v2.map(Number);
 
     function isValidPart(x) {
         return (/^\d+$/).test(x);


### PR DESCRIPTION
`compareVersions` was doing string comparisons not numeric comparisons. This means that "10" is not greater than "9" instead.

The fix is to convert the version parts to numbers.

All tests have passed.