### PR TITLE
Fix for Issue #36 (whitelist webkit-autofill selector)

### DIFF
--- a/lib/checks/check-cssprefixes.js
+++ b/lib/checks/check-cssprefixes.js
@@ -48,6 +48,7 @@ CSSLint.addRule({
     init: function (parser, reporter) {
         var rule = this,
             compatiblePrefixes,
+            whitelistedSelectors,
             properties,
             prop,
             variations,
@@ -57,6 +58,10 @@ CSSLint.addRule({
             inKeyFrame = false,
             arrayPush = Array.prototype.push,
             applyTo = [];
+            
+        whitelistedSelectors = [
+            ":-webkit-autofill"
+        ];
         
         // See http://peter.sh/experiments/vendor-prefixed-css-property-overview/ for details
         compatiblePrefixes = {
@@ -170,6 +175,7 @@ CSSLint.addRule({
                 return;
             }
             
+            
             var propertyGroups = {},
                 i,
                 len,
@@ -179,7 +185,20 @@ CSSLint.addRule({
                 value,
                 full,
                 actual,
-                item;
+                item,
+                allowedSelector,
+                selector;
+
+            // Check if the css selector is whitelisted
+            // Certain selectors can be whitelisted as they contain browser specific
+            // styles used to fix/modify browser specific behaviour
+            selector = event.selectors[0].text;
+            for( i = 0; i < whitelistedSelectors.length; i++) {
+                allowedSelector = whitelistedSelectors[i];
+                if (selector.indexOf(allowedSelector) > -1) {
+                    return;
+                }
+            }           
             
             for (i = 0, len = properties.length; i < len; i++) {
                 name = properties[i];
@@ -237,7 +256,7 @@ CSSLint.addRule({
                     }
                     
                     if (missing.length) {
-                        reporter.report(missing, value.actualNodes[0].line, value.actualNodes[0].col, rule, event.selectors[0].text);
+                        reporter.report(missing, value.actualNodes[0].line, value.actualNodes[0].col, rule, selector);
                     }
                 }
             }

--- a/static/cssprefixes-24.html
+++ b/static/cssprefixes-24.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title></title>
+    <meta name="description" content="The following css selectors are whitelisted as there is no IE or Standard equivalent but developers need to reset/set their value for Chrome & FireFox. Example: http://stackoverflow.com/questions/2920306/google-chrome-form-autofill-and-its-yellow-background">
+    <style>
+        input:-webkit-autofill {
+            -webkit-box-shadow: 0 0 0 1000px #fff inset;
+        }
+    </style>
+</head>
+<body>
+<h1>Whitelisted Selectors</h1>
+
+<p>Expected result: <b>Passes</b></p>
+</body>
+</html>

--- a/test/cssprefixes_test.js
+++ b/test/cssprefixes_test.js
@@ -97,4 +97,5 @@ module.exports['CSS Prefixes'] = {
     'Missing prefixes, only one whitelisted': checkPage("22.html", { passed: false }, ["transform"]),
     /* Configured Whitelisted properties (source: whitelisted-properites.json) */
     'Whitelisted padding & margin prefixes': checkPage("23.html", { passed: true }, globalWhitelistedProperties),
+    'Whitelisted selectors': checkPage("24.html", { passed: true })
 };


### PR DESCRIPTION
This merge adds the ability to whitelist css selectors and introduces the `:-webkit-autofill` to be allowed. It also contains unit tests to verify this functionality.